### PR TITLE
Disable sessions and cookies so CDN can cache HTML

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  skip_forgery_protection
+  before_action { request.session_options[:skip] = true }
   include Pagy::Backend
 
   before_action :set_cache_headers

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,6 @@
       <%= meta_title %>
     </title>
     <meta name="description" content="<%= meta_description %>">
-    <%= csrf_meta_tags %>
     <%= stylesheet_link_tag "application", :media => "all" %>
     <%= javascript_include_tag "application" %>
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,10 @@ module Papers
     config.exceptions_app = self.routes
     config.active_support.to_time_preserves_timezone = :zone
 
+    config.session_store :disabled
+    config.middleware.delete ActionDispatch::Session::CookieStore
+    config.middleware.delete ActionDispatch::Cookies
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/test/controllers/cache_headers_test.rb
+++ b/test/controllers/cache_headers_test.rb
@@ -29,4 +29,22 @@ class CacheHeadersTest < ActionDispatch::IntegrationTest
     assert_match(/s-maxage=3600/, cache_control)
     assert_match(/max-age=300/, cache_control)
   end
+
+  test "html pages do not set cookies" do
+    get papers_url
+    assert_response :success
+    assert_nil response.headers['Set-Cookie']
+  end
+
+  test "paper show does not set cookies" do
+    get paper_url(papers(:one))
+    assert_response :success
+    assert_nil response.headers['Set-Cookie']
+  end
+
+  test "api endpoints do not set cookies" do
+    get api_v1_papers_url, as: :json
+    assert_response :success
+    assert_nil response.headers['Set-Cookie']
+  end
 end


### PR DESCRIPTION
`csrf_meta_tags` in the layout writes `_csrf_token` to the session on every render, which forces a `Set-Cookie: _papers_session=...` header on every response. Cloudflare (with origin cache control) returns `cf-cache-status: BYPASS` for responses carrying `Set-Cookie`, and APISIX `proxy-cache` never stores them, so the existing `s-maxage` cache headers are ignored:

```
$ curl -sI https://papers.ecosyste.ms/
set-cookie: _papers_session=...
apisix-cache-status: EXPIRED
cf-cache-status: BYPASS
```

There's no login on this app, so:

- `config.session_store :disabled` and remove `ActionDispatch::Cookies` / `Session::CookieStore` from the middleware stack
- drop `csrf_meta_tags` from the layout
- `skip_forgery_protection` + `request.session_options[:skip] = true` in `ApplicationController`
- tests asserting no `Set-Cookie` on HTML and API responses

No `Sidekiq::Web` is mounted here so no separate session middleware is needed.

Same change as ecosyste-ms/awesome#793, which took `cf-cache-status: BYPASS` to `HIT` at both APISIX and Cloudflare.